### PR TITLE
Add ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+# See: https://docs.readthedocs.io/en/latest/yaml-config.html
+python:
+  version: 3
+  pip_install: true
+  extra_requirements:
+    - docs


### PR DESCRIPTION
I didn't include this in my initial PR for documentation building because I didn't want to make it too complicated. This file tells RTD to look inside setup.cfg for some extra requirements necessary to build the docs. Should solve the build issue